### PR TITLE
Clone and deploy project with error handling

### DIFF
--- a/EXPRESS_V5_FIX_SUMMARY.md
+++ b/EXPRESS_V5_FIX_SUMMARY.md
@@ -1,0 +1,65 @@
+# Express v5 Path-to-Regexp Error Fix
+
+## Issue Description
+
+The application was failing to start with Express v5 due to the following error:
+
+```
+TypeError: Missing parameter name at 1: https://git.new/pathToRegexpError
+    at name (/workspace/backend/node_modules/path-to-regexp/dist/index.js:73:19)
+    at lexer (/workspace/backend/node_modules/path-to-regexp/dist/index.js:91:27)
+```
+
+## Root Cause
+
+Express v5 introduced breaking changes to route pattern matching by upgrading the `path-to-regexp` library from version 0.x to 8.x. One of the key changes is that **wildcards must be explicitly named**.
+
+The specific line causing the issue was:
+```javascript
+app.options('*', cors());
+```
+
+In Express v4, this wildcard pattern was acceptable, but Express v5 requires all wildcards to have names.
+
+## Solution
+
+Changed the problematic wildcard route from:
+```javascript
+app.options('*', cors());
+```
+
+To:
+```javascript
+app.options('/*catchall', cors());
+```
+
+## Key Changes Made
+
+1. **Fixed wildcard route pattern**: Changed `'*'` to `'/*catchall'` to comply with Express v5 requirements
+2. **Added explanatory comment**: Documented the change for future reference
+
+## Verification
+
+After applying the fix:
+- ✅ Server starts successfully with Express v5
+- ✅ No path-to-regexp errors
+- ✅ All middleware (CORS, express-fileupload, etc.) working properly
+- ✅ Application shows "Server is running on port 4000"
+
+## Express v5 Breaking Changes Summary
+
+For future reference, here are the key Express v5 changes that affect route patterns:
+
+1. **Named wildcards required**: `*` becomes `/*name` or `*name`
+2. **Optional parameters syntax**: `:name?` becomes `{:name}`
+3. **No more regex in routes**: `/:id(\\d+)` no longer supported
+4. **Reserved characters**: `(`, `)`, `[`, `]`, `?`, `+`, `!` are now reserved
+5. **All parameters must be named**: No more accessing by index
+
+## Files Modified
+
+- `backend/app.js`: Fixed the wildcard route pattern in CORS options handler
+
+## Status
+
+✅ **RESOLVED** - The application now runs successfully with Express v5.1.0

--- a/backend/app.js
+++ b/backend/app.js
@@ -35,7 +35,8 @@ app.use(
 );
 
 // Additional OPTIONS handler for any missed preflight requests
-app.options('*', cors());
+// Express v5 requires named wildcards - changed from app.options('*', cors()) 
+app.options('/*catchall', cors());
 
 app.use(cookieParser());
 app.use(express.json());


### PR DESCRIPTION
Update wildcard route in CORS options to comply with Express v5 named wildcard requirements.

The application was failing to deploy with a `TypeError: Missing parameter name` from the `path-to-regexp` library. This was due to Express v5's breaking change requiring all wildcards in route patterns to be explicitly named (e.g., `*` becomes `/*catchall`). The `app.options('*', cors())` line was the culprit, which has now been updated to `app.options('/*catchall', cors())`.