### PR TITLE
Handle 404 error for profile update

### DIFF
--- a/ROUTE_MISMATCH_FIX.md
+++ b/ROUTE_MISMATCH_FIX.md
@@ -1,0 +1,41 @@
+# Route Mismatch Fix - 404 Error Resolution
+
+## Issue
+The frontend was receiving 404 errors when trying to call user-related API endpoints due to route mismatches between frontend and backend.
+
+## Root Cause
+The backend routes didn't match what the frontend was expecting:
+
+### Before Fix:
+- **Frontend expected**: `/api/v1/user/me/profile/update`
+- **Backend had**: `/api/v1/user/update/me`
+
+- **Frontend expected**: `/api/v1/user/password/update`  
+- **Backend had**: `/api/v1/user/update/password`
+
+## Solution
+Updated the backend routes in `backend/routes/userRoutes.js` to match frontend expectations:
+
+### Changes Made:
+1. **Profile Update Route**:
+   - Changed from: `router.put("/update/me", isAuthenticated, updateProfile);`
+   - Changed to: `router.put("/me/profile/update", isAuthenticated, updateProfile);`
+
+2. **Password Update Route**:
+   - Changed from: `router.put("/update/password", isAuthenticated, updatePassword)`
+   - Changed to: `router.put("/password/update", isAuthenticated, updatePassword)`
+
+## Final Route Structure
+The backend now provides these endpoints that match frontend expectations:
+- `PUT /api/v1/user/me/profile/update` - Update user profile
+- `PUT /api/v1/user/password/update` - Update user password
+
+## Testing
+1. Restart your backend server
+2. Try updating your profile from the frontend
+3. The 404 errors should now be resolved
+
+## Notes
+- The new route structure follows a more RESTful pattern
+- All routes are properly protected with the `isAuthenticated` middleware
+- No frontend changes were required

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -8,8 +8,8 @@ router.post("/register", register);
 router.post("/login", login); 
 router.get("/logout", isAuthenticated, logout); 
 router.get("/me", isAuthenticated, getUser)
-router.put("/update/me", isAuthenticated, updateProfile); 
-router.put("/update/password", isAuthenticated, updatePassword)
+router.put("/me/profile/update", isAuthenticated, updateProfile); 
+router.put("/password/update", isAuthenticated, updatePassword)
 router.get("/me/portfolio", getUserForPortfolio);
 router.post("/password/forgot", forgotPassword);
 router.put("/password/reset/:token", isAuthenticated, resetPassword); 


### PR DESCRIPTION
Fix 404 errors by aligning backend user profile and password update routes with frontend expectations.

The frontend was attempting to call `/api/v1/user/me/profile/update` and `/api/v1/user/password/update`, but the backend routes were defined as `/api/v1/user/update/me` and `/api/v1/user/update/password` respectively, leading to 404 Not Found errors.