### PR TITLE
Understand and resolve CORS policy errors

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -58,7 +58,8 @@ app.use(
       "Accept", 
       "Origin",
       "Cache-Control",
-      "X-File-Name"
+      "X-File-Name",
+      "timeout"
     ],
     credentials: true,
     optionsSuccessStatus: 200, // For legacy browser support

--- a/portfolio/src/pages/miniComponents/Contact.jsx
+++ b/portfolio/src/pages/miniComponents/Contact.jsx
@@ -46,10 +46,9 @@ const Contact = () => {
           {
             withCredentials: true,
             headers: { 
-              "Content-Type": "application/json",
-              // Add timeout to prevent hanging requests
-              timeout: 10000
+              "Content-Type": "application/json"
             },
+            timeout: 10000
           }
         );
         


### PR DESCRIPTION
Fix CORS error by correcting Axios `timeout` option usage and updating backend allowed headers.

The `timeout` property was mistakenly placed inside the `headers` object in the Axios request, causing it to be sent as an invalid HTTP header. This led to a CORS preflight error because the backend's `Access-Control-Allow-Headers` did not permit this non-standard header. The fix moves `timeout` to its correct place as an Axios configuration option and adds it to the backend's allowed headers as a safeguard.